### PR TITLE
Fix broken link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ next: ./config.html
 
 The [LEMP](https://en.wikipedia.org/wiki/LAMP_%28software_bundle%29) stack is a common infrastructure designed to run PHP applications.
 
-Lando offers a configurable [recipe](https://socs.lando.dev/config/recipes.html) for developing [LEMP](https://en.wikipedia.org/wiki/LAMP_%28software_bundle%29) apps.
+Lando offers a configurable [recipe](https://docs.lando.dev/config/recipes.html) for developing [LEMP](https://en.wikipedia.org/wiki/LAMP_%28software_bundle%29) apps.
 
 Note that this recipe is for a generic LEMP stack. Definitely check out Lando's [other recipes](https://socs.lando.dev/config/recipes.html) before you use this as there may be one designed specifically for use with your framework.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ The [LEMP](https://en.wikipedia.org/wiki/LAMP_%28software_bundle%29) stack is a 
 
 Lando offers a configurable [recipe](https://docs.lando.dev/config/recipes.html) for developing [LEMP](https://en.wikipedia.org/wiki/LAMP_%28software_bundle%29) apps.
 
-Note that this recipe is for a generic LEMP stack. Definitely check out Lando's [other recipes](https://socs.lando.dev/config/recipes.html) before you use this as there may be one designed specifically for use with your framework.
+Note that this recipe is for a generic LEMP stack. Definitely check out Lando's [other recipes](https://docs.lando.dev/config/recipes.html) before you use this as there may be one designed specifically for use with your framework.
 
 #### Features of this plugin:
 


### PR DESCRIPTION
A docs link has a typo which causes a broken link.