### PR TITLE
Fixed a broken link due to a typo

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -62,4 +62,4 @@ curl -fsSL -o database.sql.gz "https://url.to.my.db/database.sql.gz"
 lando db-import database.sql.gz
 ```
 
-You can learn more about the `db-import` command [over here](https://socs.lando.dev/guides/db-import.html).
+You can learn more about the `db-import` command [over here](https://docs.lando.dev/guides/db-import.html).


### PR DESCRIPTION
Fixed a broken link on this page due to a typo in the link's url

[docs.lando.dev/lemp/tooling.html](https://docs.lando.dev/lemp/tooling.html)