### PR TITLE
feat: update @lando/php to ^1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated to [@lando/php@1.12.0](https://github.com/lando/php/releases/tag/v1.12.0) for mod_headers/mod_expires and xdebug log fix
+
 * Removed `--ansi` flag from composer tooling command to prevent escape codes in redirected output
 * Fixed MySQL 8.4 startup failure by removing hardcoded `mysql_native_password` authentication [lando/mysql#69](https://github.com/lando/mysql/issues/69)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lando/mongo": "^1.4.0",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.10.0",
+        "@lando/php": "^1.12.0",
         "@lando/postgres": "^1.5.0",
         "lodash": "^4.17.21"
       },
@@ -1506,9 +1506,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.2.tgz",
-      "integrity": "sha512-1fsT+GPThmUkB8X5iprBkX+VBoor/sXB8/oOwGFabeeVCcVq6ymDSBWgs8Qf2hdoxJiJcNT871//ohkQaotLYw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.12.0.tgz",
+      "integrity": "sha512-yHhjdtGv0zgylfOubbWz09ufTr8yfi7so262RDJT5P03T24LfHPOBLFLTtdI8I1k0kzH9phxhQ4aZyex9TMhsg==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lando/mongo": "^1.4.0",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.10.0",
+    "@lando/php": "^1.12.0",
     "@lando/postgres": "^1.5.0",
     "lodash": "^4.17.21"
   },


### PR DESCRIPTION
## Changes

- Updated `@lando/php` to `^1.12.0`

## What's in @lando/php v1.12.0

- Enabled mod_headers and mod_expires Apache modules by default ([php#244](https://github.com/lando/php/pull/244))
- Fixed xdebug log file ownership issue when build_as_root or run_as_root creates /tmp/xdebug.log as root ([php#242](https://github.com/lando/php/pull/242))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump changes the underlying PHP service image/config defaults (Apache modules) and debugging behavior, which could affect runtime behavior in downstream projects.
> 
> **Overview**
> Updates the plugin’s `@lando/php` dependency to `^1.12.0` (and refreshes the lockfile accordingly).
> 
> Adds an UNRELEASED changelog entry noting the upstream changes, including enabling `mod_headers`/`mod_expires` by default and an xdebug log ownership fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca693aa90b9f19b424678894cd9657d0e8c10fed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->